### PR TITLE
feat: detect I2C address

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCP23008 library
-version=1.1.0
+version=1.2.0
 author=Strooom
 maintainer=Strooom <pascal.roobrouck@gmail.com>
 sentence=Arduino Library for the MCP23008 I/O expander - I2C interface only

--- a/src/MCP23008.cpp
+++ b/src/MCP23008.cpp
@@ -3,7 +3,20 @@
 #include <Wire.h>           // the device can interface I2C or SPI. This driver only does I2C, so we include the I2C library
 #include <Arduino.h>        // for definition of INPUT, OUTPUT, etc
 
-MCP23008::MCP23008(uint8_t theI2Caddress) : I2Caddress(theI2Caddress) {
+void MCP23008::discoverI2cAddress(uint8_t startAddress) {
+    for (uint8_t candidateI2cAddress = startAddress; candidateI2cAddress <= 0x27; candidateI2cAddress++) {        // scan all possible I2C addresses for this device
+        Wire.beginTransmission(candidateI2cAddress);
+        if (Wire.endTransmission() == 0) {
+            I2Caddress = candidateI2cAddress;
+            return;
+        }
+    }
+    I2Caddress = 0;
+    return;
+}
+
+bool MCP23008::isPresent() const {
+    return (I2Caddress != 0);
 }
 
 void MCP23008::initialize() {

--- a/src/MCP23008.h
+++ b/src/MCP23008.h
@@ -3,26 +3,27 @@
 
 class MCP23008 {
   public:
-    explicit MCP23008(uint8_t I2Caddress = 0x20);        // default I2C address of this device is 0x20. By configuring some HW pins (A2, A1, A0) you can modify that address.
-    void initialize();                                   // device is ready for use after powerOn reset. This resets all settings to powerOn reset defaults.
+    void discoverI2cAddress(uint8_t startAddress = 0x20);        // scans I2C addresses 0x20 to 0x27 to detect an MCP23008 and stores the found address inside the object. To detect multiple MCP23008, first discover with no startAddress parameter (taking default 0x20), then repeat with startAddress = found address + 1, until not found or found on 0x27
+    bool isPresent() const;                                      // returns true if the device is present on the I2C bus
+    void initialize();                                           // device is ready for use after powerOn reset. This resets all settings to powerOn reset defaults.
 
     uint8_t getI2cAddress() const;
     void pinMode(uint8_t pin, uint8_t theMode);           // Arduino-style configuration of each individual IO
     void digitalWrite(uint8_t pin, uint8_t value);        // Arduino-style writing of a HIGH or LOW to an individual IO
     uint8_t digitalRead(uint8_t pin) const;               // Arduino-style reading an individual IO
 
-    enum class registerAddress : uint8_t {        // definition of all the registers this device has
-        IODIR   = 0x00,                           // I/O Direction
-        IPOL    = 0x01,                           // Input Polarity
-        GPINTEN = 0x02,                           // Interrupt On Change pins
-        DEFVAL  = 0x03,                           // Default Value
-        INTCON  = 0x04,                           // Interrupt Control
-        IOCON   = 0x05,                           // I/O Expander Configuration
-        GPPU    = 0x06,                           // GPIO PullUp Resistor
-        INTF    = 0x07,                           // Interrupt Flag
-        INTCAP  = 0x08,                           // Interrupt Capture
-        GPIO    = 0x09,                           // General Purpose IO
-        OLAT    = 0x0A,                           // Output Latch
+    enum class registerAddress : uint8_t {                // definition of all the registers this device has
+        IODIR   = 0x00,                                   // I/O Direction
+        IPOL    = 0x01,                                   // Input Polarity
+        GPINTEN = 0x02,                                   // Interrupt On Change pins
+        DEFVAL  = 0x03,                                   // Default Value
+        INTCON  = 0x04,                                   // Interrupt Control
+        IOCON   = 0x05,                                   // I/O Expander Configuration
+        GPPU    = 0x06,                                   // GPIO PullUp Resistor
+        INTF    = 0x07,                                   // Interrupt Flag
+        INTCAP  = 0x08,                                   // Interrupt Capture
+        GPIO    = 0x09,                                   // General Purpose IO
+        OLAT    = 0x0A,                                   // Output Latch
         nmbrOfRegisters
     };
     static constexpr uint32_t nmbrOfRegisters = static_cast<uint32_t>(registerAddress::nmbrOfRegisters);
@@ -38,6 +39,6 @@ class MCP23008 {
 #endif
 
     void writeHardwareRegister(registerAddress address, uint8_t value);        // write a value to a register at address xx to the HW device
-    uint8_t I2Caddress;                                                        // remembers the I2C address of each instance - default is 0x20
+    uint8_t I2Caddress{0};                                                     // remembers the I2C address of each instance - 0 means : no device found
     uint8_t mcuCopyOfRegisters[nmbrOfRegisters];                               // RAM copies of all register values, so we can refresh the HW
 };

--- a/src/MCP23008.md
+++ b/src/MCP23008.md
@@ -1,0 +1,12 @@
+# MCP23008 Driver
+
+This driver has the following (extra) features :
+* it can detect at which address the MCP23008 is present. Multiple MCP23008 can be detected. They can have I2C address 0x20 to 0x27 by configuring HW pins A0..A2
+* it keeps a shadow copy of the MCP23008 registers in RAM, allowing to :
+    * detect a corrupt device config (some internal bits changed due to EMC or whatever HW problem)
+    * refresh the device configuration regularly
+
+
+* The target unit tests expect some specific HW configuration in order to pass:
+    * I2C address is 0x21
+    * there is a HW loopback from GPIO3 (out) to GPIO6 (in)

--- a/test/test_target_general/test.cpp
+++ b/test/test_target_general/test.cpp
@@ -1,8 +1,21 @@
 #include <Arduino.h>
+#include <Wire.h>
 #include <unity.h>
 #include <MCP23008.h>
 
 MCP23008 ioExtender;        // create an instance, default address. As it is a global instance, there are side effects from one test to the next tests !
+
+void test_discoverAddress() {
+    TEST_ASSERT_FALSE(ioExtender.isPresent());
+    TEST_ASSERT_EQUAL_UINT8(0, ioExtender.getI2cAddress());
+
+    ioExtender.discoverI2cAddress(0x22);                              // there is only one device on our test HW, so this should fail
+    TEST_ASSERT_FALSE(ioExtender.isPresent());
+
+    ioExtender.discoverI2cAddress();
+    TEST_ASSERT_TRUE(ioExtender.isPresent());
+    TEST_ASSERT_EQUAL_UINT8(0x21, ioExtender.getI2cAddress());        // this test was done with powerpcb v2, which has the MCP23008 at address 0x21
+}
 
 void test_read_write_registers() {
     // I am avoiding setting bit 6 as output, as on my test HW it is driven by something as an input, so setting it as output is a conflict
@@ -23,10 +36,6 @@ void test2_read_write_registers() {
     TEST_ASSERT_EQUAL_UINT8(0xAA, ioExtender.readRegister(MCP23008::registerAddress::OLAT));
     ioExtender.writeRegister(MCP23008::registerAddress::GPIO, 0x55);                                // writing GPIO
     TEST_ASSERT_EQUAL_UINT8(0x55, ioExtender.readRegister(MCP23008::registerAddress::OLAT));        // but reading OLAT
-}
-
-void test_getAddress() {
-    TEST_ASSERT_EQUAL_UINT8(0x20, ioExtender.getI2cAddress());
 }
 
 void test_refresh() {
@@ -71,7 +80,7 @@ void test_pinmode() {
     TEST_ASSERT_EQUAL_UINT8(0x00, ioExtender.readRegister(MCP23008::registerAddress::GPPU));
 }
 
-void test1_digitalWrite() {
+void test_digitalWrite() {
     ioExtender.pinMode(0, OUTPUT);
     ioExtender.digitalWrite(0, 0);
     TEST_ASSERT_EQUAL_UINT8(0x00, ioExtender.readRegister(MCP23008::registerAddress::OLAT));
@@ -79,28 +88,52 @@ void test1_digitalWrite() {
     TEST_ASSERT_EQUAL_UINT8(0x01, ioExtender.readRegister(MCP23008::registerAddress::OLAT));
 }
 
-void test2_digitalWrite() {
-    TEST_IGNORE();        // I need a hw loopback from output to input, to complete this test
+void test_digitalWriteRead() {
+    // this test requires a hw loopback from output GPIO3 to input GPIO6 to pass this test
+    // the loopback is inverting, ie a low output, results in a high input and vice versa
+    ioExtender.pinMode(3, OUTPUT);
+    ioExtender.pinMode(6, INPUT);
+
+    ioExtender.digitalWrite(3, 0);
+    TEST_ASSERT_EQUAL_UINT8(1, ioExtender.digitalRead(6));
+
+    ioExtender.digitalWrite(3, 1);
+    TEST_ASSERT_EQUAL_UINT8(0, ioExtender.digitalRead(6));
 }
 
-void test_digitalRead() {
-    TEST_IGNORE();        // I need a hw loopback from output to input, to complete this test
+void test_relay() {
+    // This test  switches the latching relay on GPIO4 and GPIO5 on and off, which can be heard as a click
+    // No automatic test
+    ioExtender.pinMode(4, OUTPUT);
+    ioExtender.pinMode(5, OUTPUT);
+    for (auto i = 0; i < 8; i++) {
+        ioExtender.digitalWrite(5, 1);
+        delay(100);
+        ioExtender.digitalWrite(5, 0);
+        delay(500);
+        ioExtender.digitalWrite(4, 1);
+        delay(100);
+        ioExtender.digitalWrite(4, 0);
+        delay(500);
+    }
+    TEST_IGNORE_MESSAGE("No automatic testresults - please listen to the relay clicks");
 }
 
 void setup() {
+    delay(1000);         // some delay to allow the PCs serial monitor to start up
+    Wire.begin();        // enables I2C communication in general
+
     UNITY_BEGIN();
-    ioExtender.initialize();
+    RUN_TEST(test_discoverAddress);
     RUN_TEST(test_read_write_registers);
     RUN_TEST(test2_read_write_registers);
-    RUN_TEST(test_getAddress);
     RUN_TEST(test_refresh);
     RUN_TEST(test2_refresh);
     RUN_TEST(test_verify);
     RUN_TEST(test_pinmode);
-    RUN_TEST(test1_digitalWrite);
-    RUN_TEST(test2_digitalWrite);
-    RUN_TEST(test_digitalRead);
-
+    RUN_TEST(test_digitalWrite);
+    RUN_TEST(test_digitalWriteRead);
+    RUN_TEST(test_relay);
     UNITY_END();
 }
 


### PR DESCRIPTION
Rather than knowing the I2C address, the driver can now search for devices in the possible range of I2C addresses.

unit tests were updated for this new feature